### PR TITLE
Fix/disable github actions in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,14 +16,14 @@ updates:
       - "MatijaSokol"
     labels:
       - "Dependencies"
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-      time: "09:00"
-      timezone: "Europe/Zagreb"
-    open-pull-requests-limit: 5
-    reviewers:
-      - "MatijaSokol"
-    labels:
-      - "GitHub Actions"
+#  - package-ecosystem: "github-actions"
+#    directory: "/"
+#    schedule:
+#      interval: "weekly"
+#      time: "09:00"
+#      timezone: "Europe/Zagreb"
+#    open-pull-requests-limit: 5
+#    reviewers:
+#      - "MatijaSokol"
+#    labels:
+#      - "GitHub Actions"


### PR DESCRIPTION
Github actions are still not set in project so dependabot shouldn't reference it.

```
Dependabot couldn't find a <anything>.yml
Dependabot requires a .yml to evaluate your GitHub Actions dependencies. It had expected to find one at the path: /action.yml or /.github/workflows/<anything>.yml.

If this isn't a GitHub Actions project, you may wish to disable updates for it in the .github/dependabot.yml config file in this repo.
```